### PR TITLE
Amend known failure files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -242,6 +242,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [The Way](https://github.com/out-of-cheese-error/the-way), a code snippets manager for your terminal that uses `syntect`for highlighting.
 - [Broot](https://github.com/Canop/broot), a terminal file manager, uses `syntect` for file previews.
 - [Rusty Slider](https://ollej.github.io/rusty-slider/), a markdown slideshow presentation application, uses `syntect` for code blocks.
+- [BugStalker](https://github.com/godzie44/BugStalker/), modern debugger for Linux x86-64. Written in Rust for Rust programs.
 
 
 ## License and Acknowledgements

--- a/src/parsing/metadata.rs
+++ b/src/parsing/metadata.rs
@@ -493,13 +493,13 @@ mod tests {
 
     #[test]
     fn load_raw() {
-        let comments_file: &str = "testdata/Packages/Go/Comments.tmPreferences";
+        let comments_file: &str = "testdata/Packages/Go/GoCommentRules.tmPreferences";
         assert!(Path::new(comments_file).exists());
 
         let r = RawMetadataEntry::load(comments_file);
         assert!(r.is_ok());
 
-        let indent_file: &str = "testdata/Packages/Go/Indentation Rules.tmPreferences";
+        let indent_file: &str = "testdata/Packages/Go/Indents/GoIndent.tmPreferences";
         assert!(Path::new(indent_file).exists());
 
         let r = RawMetadataEntry::load(indent_file).unwrap();

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -757,24 +757,35 @@ mod tests {
         let ops1 = ops(&mut state, "module Bob::Wow::Troll::Five; 5; end", &ss);
         let test_ops1 = vec![
             (0, Push(Scope::new("source.ruby.rails").unwrap())),
-            (0, Push(Scope::new("meta.module.ruby").unwrap())),
-            (0, Push(Scope::new("keyword.control.module.ruby").unwrap())),
+            (0, Push(Scope::new("meta.namespace.ruby").unwrap())),
+            (0, Push(Scope::new("storage.type.namespace.ruby").unwrap())),
+            (
+                0,
+                Push(Scope::new("keyword.declaration.namespace.ruby").unwrap()),
+            ),
             (6, Pop(2)),
-            (6, Push(Scope::new("meta.module.ruby").unwrap())),
             (7, Pop(1)),
-            (7, Push(Scope::new("meta.module.ruby").unwrap())),
-            (7, Push(Scope::new("entity.name.module.ruby").unwrap())),
+            (7, Push(Scope::new("meta.namespace.ruby").unwrap())),
+            (7, Push(Scope::new("entity.name.namespace.ruby").unwrap())),
             (7, Push(Scope::new("support.other.namespace.ruby").unwrap())),
             (10, Pop(1)),
-            (10, Push(Scope::new("punctuation.accessor.ruby").unwrap())),
+            (
+                10,
+                Push(Scope::new("punctuation.accessor.double-colon.ruby").unwrap()),
+            ),
+            (12, Pop(1)),
         ];
         assert_eq!(&ops1[0..test_ops1.len()], &test_ops1[..]);
 
         let ops2 = ops(&mut state, "def lol(wow = 5)", &ss);
-        let test_ops2 = vec![
+        let test_ops2 = [
             (0, Push(Scope::new("meta.function.ruby").unwrap())),
-            (0, Push(Scope::new("keyword.control.def.ruby").unwrap())),
-            (3, Pop(2)),
+            (0, Push(Scope::new("storage.type.function.ruby").unwrap())),
+            (
+                0,
+                Push(Scope::new("keyword.declaration.function.ruby").unwrap()),
+            ),
+            (3, Pop(3)),
             (3, Push(Scope::new("meta.function.ruby").unwrap())),
             (4, Push(Scope::new("entity.name.function.ruby").unwrap())),
             (7, Pop(1)),
@@ -829,6 +840,7 @@ mod tests {
         test_stack.push(Scope::new("text.html.basic").unwrap());
         test_stack.push(Scope::new("source.js.embedded.html").unwrap());
         test_stack.push(Scope::new("source.js").unwrap());
+        test_stack.push(Scope::new("meta.string.js").unwrap());
         test_stack.push(Scope::new("string.quoted.single.js").unwrap());
         test_stack.push(Scope::new("source.ruby.rails.embedded.html").unwrap());
         test_stack.push(Scope::new("meta.function.parameters.ruby").unwrap());
@@ -860,38 +872,37 @@ mod tests {
                     Push(Scope::new("keyword.operator.assignment.ruby").unwrap())
                 ),
                 (5, Pop(1)),
-                (
-                    6,
-                    Push(Scope::new("string.unquoted.embedded.sql.ruby").unwrap())
-                ),
+                (6, Push(Scope::new("meta.string.heredoc.ruby").unwrap())),
+                (6, Push(Scope::new("string.unquoted.heredoc.ruby").unwrap())),
                 (
                     6,
                     Push(Scope::new("punctuation.definition.string.begin.ruby").unwrap())
                 ),
+                (12, Pop(2)),
                 (12, Pop(1)),
-                (12, Pop(1)),
+                (12, Push(Scope::new("meta.string.heredoc.ruby").unwrap())),
+                (12, Push(Scope::new("source.sql.embedded.ruby").unwrap())),
+                (12, Clear(ClearAmount::TopN(2))),
                 (
                     12,
-                    Push(Scope::new("string.unquoted.embedded.sql.ruby").unwrap())
+                    Push(Scope::new("punctuation.accessor.dot.ruby").unwrap())
                 ),
-                (12, Push(Scope::new("text.sql.embedded.ruby").unwrap())),
-                (12, Clear(ClearAmount::TopN(2))),
-                (12, Push(Scope::new("punctuation.accessor.ruby").unwrap())),
                 (13, Pop(1)),
-                (18, Restore),
             ]
         );
 
-        assert_eq!(ops(&mut state, "wow", &ss), vec![]);
+        assert_eq!(ops(&mut state, "wow", &ss), vec![(0, Restore)]);
 
         assert_eq!(
             ops(&mut state, "SQL", &ss),
             vec![
                 (0, Pop(1)),
+                (0, Push(Scope::new("string.unquoted.heredoc.ruby").unwrap())),
                 (
                     0,
                     Push(Scope::new("punctuation.definition.string.end.ruby").unwrap())
                 ),
+                (3, Pop(1)),
                 (3, Pop(1)),
                 (3, Pop(1)),
             ]
@@ -998,8 +1009,8 @@ mod tests {
         let mut state1 = ParseState::new(syntax);
         let mut state2 = ParseState::new(syntax);
 
-        assert_eq!(ops(&mut state1, "class Foo {", &ss).len(), 11);
-        assert_eq!(ops(&mut state2, "class Fooo {", &ss).len(), 11);
+        assert_eq!(ops(&mut state1, "class Foo {", &ss).len(), 12);
+        assert_eq!(ops(&mut state2, "class Fooo {", &ss).len(), 12);
 
         assert_eq!(state1, state2);
         ops(&mut state1, "}", &ss);

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -1032,7 +1032,7 @@ mod tests {
             .get_context(&syntax.context_ids()["main"])
             .expect("#[cfg(test)]");
         let count = syntax_definition::context_iter(&ps, main_context).count();
-        assert_eq!(count, 109);
+        assert_eq!(count, 168);
     }
 
     #[test]

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,5 +1,15 @@
 loading syntax definitions from testdata/Packages
-FAILED testdata/Packages/C#/tests/syntax_test_Strings.cs: 38
+FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
+FAILED testdata/Packages/Erlang/syntax_test_erlang.erl: 783
+FAILED testdata/Packages/Git Formats/syntax_test_git_config: 17
+FAILED testdata/Packages/Git Formats/syntax_test_git_rebase: 3
+FAILED testdata/Packages/JSON/syntax_test_json.json: 4
+FAILED testdata/Packages/Java/syntax_test_java.java: 817
+FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 47
 FAILED testdata/Packages/LaTeX/syntax_test_latex.tex: 1
 FAILED testdata/Packages/Makefile/syntax_test_makefile.mak: 6
+FAILED testdata/Packages/Markdown/syntax_test_markdown.md: 3920
+FAILED testdata/Packages/PHP/syntax_test_php.php: 22
+FAILED testdata/Packages/Ruby/syntax_test_ruby.rb: 1
+FAILED testdata/Packages/ShellScript/test/syntax_test_bash.sh: 14
 exiting with code 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,5 +1,14 @@
 loading syntax definitions from testdata/Packages
-FAILED testdata/Packages/C#/tests/syntax_test_Strings.cs: 38
+FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
+FAILED testdata/Packages/Erlang/syntax_test_erlang.erl: 783
+FAILED testdata/Packages/Git Formats/syntax_test_git_config: 17
+FAILED testdata/Packages/Git Formats/syntax_test_git_rebase: 3
+FAILED testdata/Packages/JSON/syntax_test_json.json: 4
+FAILED testdata/Packages/Java/syntax_test_java.java: 817
+FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 47
 FAILED testdata/Packages/LaTeX/syntax_test_latex.tex: 1
-FAILED testdata/Packages/Markdown/syntax_test_markdown.md: 11
+FAILED testdata/Packages/Markdown/syntax_test_markdown.md: 3920
+FAILED testdata/Packages/PHP/syntax_test_php.php: 22
+FAILED testdata/Packages/Ruby/syntax_test_ruby.rb: 1
+FAILED testdata/Packages/ShellScript/test/syntax_test_bash.sh: 14
 exiting with code 1


### PR DESCRIPTION
I'm not 100% sure this is the solution you are looking for, but given the change you are making it seems relatively sensible that the status of a few tests might have changed. Just submitting for your feedback, do let me know if this is not the right path to go down to. In practice, this makes `make assets`, `make syntest`, and `make syntest-fancy` pass (at least locally, but I don't see reasons why this should be different on CI).