### PR TITLE
[wip] allow extended syntaxed to reference updated variables

### DIFF
--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -117,6 +117,7 @@ pub struct MatchIter<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MatchPattern {
     pub has_captures: bool,
+    pub raw_regex_str: String,
     pub regex: Regex,
     pub scope: Vec<Scope>,
     pub captures: Option<CaptureMapping>,
@@ -268,6 +269,7 @@ where
 impl MatchPattern {
     pub fn new(
         has_captures: bool,
+        raw_regex_str: String,
         regex_str: String,
         scope: Vec<Scope>,
         captures: Option<CaptureMapping>,
@@ -276,6 +278,7 @@ impl MatchPattern {
     ) -> MatchPattern {
         MatchPattern {
             has_captures,
+            raw_regex_str,
             regex: Regex::new(regex_str),
             scope,
             captures,
@@ -318,6 +321,7 @@ mod tests {
     fn can_compile_refs() {
         let pat = MatchPattern {
             has_captures: true,
+            raw_regex_str: "ignored here".into(),
             regex: Regex::new(r"lol \\ \2 \1 '\9' \wz".into()),
             scope: vec![],
             captures: None,


### PR DESCRIPTION
Hi,

Thanks very much for the [PR implementing `extends`](https://github.com/trishume/syntect/pull/536). Sorry to let it linger for so long.
I had some ideas of how we could get the match patterns from the base syntax definition (which has already been parsed) to use the variables from the derived syntax definition. And that is to store the original "raw regex" on the `MatchPattern` so we can reevaluate it with the "latest" variables. It is probably not the best way to do it, but I feel like at this stage, it is better to get something implemented, merge it and improve it later...
To this end, I added a test which should succeed when everything works as expected. I confess that I haven't actually had time to complete the implementation yet, but thought I'd push it here in case you or someone else wants to take over, or in case it pushes me to find more time for it myself...